### PR TITLE
Make ZimbraConnection available to inherited AdminExtension classes

### DIFF
--- a/src/Zimbra/ZCS/Admin.php
+++ b/src/Zimbra/ZCS/Admin.php
@@ -44,6 +44,11 @@ class Admin
         return (string) $this->authToken;
     }
 
+    protected function getZimbraConnect()
+    {
+        return $this->zimbraConnect;
+    }
+
     public function searchDirectory($domain, $limit = 10, $offset = 0, $type = 'accounts', $sort = null, $query = null)
     {
         if ($type == 'accounts') {


### PR DESCRIPTION
to be able to enhance functions.

At first, thanks for the existing work. 
For some other queries, I have to implement, it would be nice to derive from the Admin class and have access to the established and authenticated connection.

My first approach was to change the visibility of $zimbraConnect to protected. But this would lead to the ability to miss configure or delete the connection by the derived class.  
So I decided to gain access by implementing this little getter method.

Regards.